### PR TITLE
Solve dependency conflict in automated_test.yml

### DIFF
--- a/.github/workflows/automated_test.yml
+++ b/.github/workflows/automated_test.yml
@@ -27,7 +27,7 @@ jobs:
       # Install all dependencies (from package.json in sync-trip)
       - name: Install Dependencies
         working-directory: ./sync-trip
-        run: npm install
+        run: npm install --legacy-peer-deps
 
       - name: Authenticate with Expo
         working-directory: ./sync-trip


### PR DESCRIPTION
because of the dependency conflict between @react-native-firebase/auth@21.12.0 and @react-native-firebase/app@21.13.0, add --legacy-peer-deps when installing dependencies.